### PR TITLE
fix: include missing values in table 1 counts

### DIFF
--- a/analysis/table_1.py
+++ b/analysis/table_1.py
@@ -11,6 +11,8 @@ def create_table_1(paths, demographics, outcome):
     for i, path in enumerate(paths):
         if i ==0:
             df = pd.read_csv(path, usecols=demographics + ["patient_id", outcome])
+            #fill in missing values
+            df.loc[:,demographics] = df.loc[:,demographics].fillna("missing")
             df_had_outcome = df.loc[df[outcome]==1,:]
             df = df.drop(outcome, axis=1)
             df_had_outcome = df_had_outcome.drop(outcome, axis=1)
@@ -18,6 +20,7 @@ def create_table_1(paths, demographics, outcome):
         
         else:
             updated_df = pd.read_csv(path, usecols=demographics + ["patient_id", outcome])
+            updated_df.loc[:,demographics] = updated_df.loc[:,demographics].fillna("missing")
             updated_df_had_outcome = updated_df.loc[updated_df[outcome]==1,:]
             updated_df = updated_df.drop(outcome, axis=1)
             updated_df_had_outcome = updated_df_had_outcome.drop(outcome, axis=1)


### PR DESCRIPTION
When running this code on real data I found that missing values (ie a value wasn't recorded for an individual throughout the entire period) weren't included. This fills in missing values with a string so that they are captured and the table sub counts are consistent 