### PR TITLE
Fix missing regions and ethnicity being dropped

### DIFF
--- a/analysis/correct_age_groups.py
+++ b/analysis/correct_age_groups.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pathlib import Path
 
 def regroupAgeGroup(df, demographic, numerator_column):
+    df[demographic]=df[demographic].fillna('Missing')
     df["AgeGroup"] = df["AgeGroup"].replace({'15-19': '18-24', '20-24': '18-24'})
     if (demographic!="sex" and demographic!="population"):
         df = df.groupby(["AgeGroup", "sex", demographic, "date"], as_index=False)[[numerator_column, 'population']].sum()

--- a/analysis/correct_age_groups.py
+++ b/analysis/correct_age_groups.py
@@ -4,16 +4,16 @@ from pathlib import Path
 def regroupAgeGroup(df, demographic, numerator_column):
     df["AgeGroup"] = df["AgeGroup"].replace({'15-19': '18-24', '20-24': '18-24'})
     if (demographic!="sex" and demographic!="population"):
-        df = df.groupby(["AgeGroup", "sex", demographic, "date"], as_index=False)[[numerator_column, 'population']].sum()
+        df = df.groupby(["AgeGroup", "sex", demographic, "date"], dropna=False, as_index=False)[[numerator_column, 'population']].sum()
     else:
-        df = df.groupby(["AgeGroup", "sex", "date"], as_index=False)[[numerator_column, 'population']].sum()
+        df = df.groupby(["AgeGroup", "sex", "date"], dropna=False, as_index=False)[[numerator_column, 'population']].sum()
     df = df.sort_values(by=['date', 'AgeGroup', 'sex', demographic])
     df["value"]=df[numerator_column]/df["population"]
     return df
 
 def regroupage_band(df, numerator_column):
     df["age_band"] = df["age_band"].replace({'0-19': '18-29', '20-29': '18-29'})
-    df = df.groupby(["sex", "age_band", "date"], as_index=False)[[numerator_column, 'population']].sum()
+    df = df.groupby(["sex", "age_band", "date"], dropna=False, as_index=False)[[numerator_column, 'population']].sum()
     df = df.sort_values(by=['date', 'age_band', 'sex'])
     df["value"]=df[numerator_column]/df["population"]
     return df

--- a/analysis/correct_age_groups.py
+++ b/analysis/correct_age_groups.py
@@ -4,16 +4,16 @@ from pathlib import Path
 def regroupAgeGroup(df, demographic, numerator_column):
     df["AgeGroup"] = df["AgeGroup"].replace({'15-19': '18-24', '20-24': '18-24'})
     if (demographic!="sex" and demographic!="population"):
-        df = df.groupby(["AgeGroup", "sex", demographic, "date"], dropna=False, as_index=False)[[numerator_column, 'population']].sum()
+        df = df.groupby(["AgeGroup", "sex", demographic, "date"], as_index=False)[[numerator_column, 'population']].sum()
     else:
-        df = df.groupby(["AgeGroup", "sex", "date"], dropna=False, as_index=False)[[numerator_column, 'population']].sum()
+        df = df.groupby(["AgeGroup", "sex", "date"], as_index=False)[[numerator_column, 'population']].sum()
     df = df.sort_values(by=['date', 'AgeGroup', 'sex', demographic])
     df["value"]=df[numerator_column]/df["population"]
     return df
 
 def regroupage_band(df, numerator_column):
     df["age_band"] = df["age_band"].replace({'0-19': '18-29', '20-29': '18-29'})
-    df = df.groupby(["sex", "age_band", "date"], dropna=False, as_index=False)[[numerator_column, 'population']].sum()
+    df = df.groupby(["sex", "age_band", "date"], as_index=False)[[numerator_column, 'population']].sum()
     df = df.sort_values(by=['date', 'age_band', 'sex'])
     df["value"]=df[numerator_column]/df["population"]
     return df

--- a/analysis/rate_calculations_demographics.py
+++ b/analysis/rate_calculations_demographics.py
@@ -106,9 +106,9 @@ def make_table(standard_pop, file, numeratorcol, denominatorcol, group_by, demog
             standardise_rates_sex_apply, standard_pop=standard_pop, axis=1)
     by_agesex.drop(['agesex_rates'], axis=1, inplace=True)
     if (demographic_var=="population"):
-        standardised_totals = by_agesex.groupby(["date"], dropna=False).sum().reset_index()
+        standardised_totals = by_agesex.groupby(["date"]).sum().reset_index()
     else:
-        standardised_totals = by_agesex.groupby(["date", demographic_var], dropna=False).sum().reset_index()
+        standardised_totals = by_agesex.groupby(["date", demographic_var]).sum().reset_index()
     if redact:
         standardised_totals = redact_small_numbers(standardised_totals, numeratorcol, denominatorcol)
     return standardised_totals

--- a/analysis/rate_calculations_demographics.py
+++ b/analysis/rate_calculations_demographics.py
@@ -106,9 +106,9 @@ def make_table(standard_pop, file, numeratorcol, denominatorcol, group_by, demog
             standardise_rates_sex_apply, standard_pop=standard_pop, axis=1)
     by_agesex.drop(['agesex_rates'], axis=1, inplace=True)
     if (demographic_var=="population"):
-        standardised_totals = by_agesex.groupby(["date"]).sum().reset_index()
+        standardised_totals = by_agesex.groupby(["date"], dropna=False).sum().reset_index()
     else:
-        standardised_totals = by_agesex.groupby(["date", demographic_var]).sum().reset_index()
+        standardised_totals = by_agesex.groupby(["date", demographic_var], dropna=False).sum().reset_index()
     if redact:
         standardised_totals = redact_small_numbers(standardised_totals, numeratorcol, denominatorcol)
     return standardised_totals

--- a/analysis/rate_calculations_demographics.py
+++ b/analysis/rate_calculations_demographics.py
@@ -49,7 +49,7 @@ def get_data(file, numeratorcol, denominatorcol, group_by, demographic_var):
     by_age["date"] = pd.to_datetime(by_age["date"])
 
     #remove people with "Missing" in demographic vars
-    by_age = by_age[by_age[demographic_var] != "Missing"]
+    #by_age = by_age[by_age[demographic_var] != "Missing"]
 
     return by_age
 


### PR DESCRIPTION
Missing regions recorded as blank fields. Blank fields read as NaN by Pandas. By default groupby drops NaN fields resulting in missing region data being dropped. Change blank region fields to "Missing" to prevent this.
Removed filtering out of "Missing" from standardisation function to preventer missing region & ethnicity being dropped.