### PR TITLE
Remove 2nd sort of legend category

### DIFF
--- a/analysis/utilities.py
+++ b/analysis/utilities.py
@@ -87,7 +87,7 @@ def plot_measures(
         else:
             categoryplotted=splitlegendlines(categoryplotted)
             plt.legend(
-                sorted(categoryplotted), bbox_to_anchor=(1.04, 1), loc="upper left", fontsize=16
+                categoryplotted, bbox_to_anchor=(1.04, 1), loc="upper left", fontsize=16
             )
 
     plt.vlines(


### PR DESCRIPTION
Unneeded as already sorted line 42.
Causing plot/legend mismatch as resorting due to rename after plotting